### PR TITLE
Fix broken links by removing module name from github links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ stdenv: &stdenv
 executors:
   container:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.21
         user: circleci
     <<: *stdenv
     working_directory: *workdir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - containedctx
     - contextcheck
     - decorder
-    - depguard
     - dogsled
     - dupl
     - dupword
@@ -89,6 +88,7 @@ linters:
     - whitespace
     - wrapcheck
     # - cyclop
+    # - depguard
     # - exhaustruct
     # - forbidigo
     # - funlen

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(GO_MODIFF_STATIC):
 
 $(GOLANGCI_LINT):
 	export \
-		VERSION=v1.52.2 \
+		VERSION=v1.55.2 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=$(BUILD_PATH) && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/saschagrunert/go-modiff
 
-go 1.20
+go 1.21
 
 require (
 	github.com/onsi/ginkgo/v2 v2.9.2

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
@@ -325,6 +326,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/modiff/modiff_test.go
+++ b/pkg/modiff/modiff_test.go
@@ -1,5 +1,6 @@
 package modiff_test
 
+//nolint:revive // test file
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/modiff/suite_test.go
+++ b/pkg/modiff/suite_test.go
@@ -1,5 +1,6 @@
 package modiff_test
 
+//nolint:revive // test file
 import (
 	"testing"
 


### PR DESCRIPTION
There is an issue with some of the links generated using the `-l` flag. Some dependencies erroneously include the module name in the GitHub link. This PR adds some logic to trim the end of the link if it includes the module name.

How to reproduce bug:
```
go-modiff -r github.com/kubernetes-sigs/cluster-api -f v1.3.9 -t v1.3.10 -l
```

Notice how some links look like this `https://github.com/cespare/xxhash/v2/compare/v2.1.2...v2.2.0` and lead to a 404 page when it should be this `https://github.com/cespare/xxhash/compare/v2.1.2...v2.2.0`.