### PR TITLE
Fix links for deps with tag that contains one slash

### DIFF
--- a/pkg/modiff/modiff_test.go
+++ b/pkg/modiff/modiff_test.go
@@ -2,6 +2,11 @@ package modiff_test
 
 //nolint:revive // test file
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/saschagrunert/go-modiff/pkg/modiff"
@@ -42,9 +47,10 @@ _Nothing has changed._
 `
 
 	const (
-		repo = "github.com/saschagrunert/go-modiff"
-		from = "v0.10.0"
-		to   = "v0.11.0"
+		repo    = "github.com/saschagrunert/go-modiff"
+		from    = "v0.10.0"
+		to      = "v0.11.0"
+		badRepo = "github.com/saschagrunert/go-modiff-invalid"
 	)
 
 	BeforeEach(func() {
@@ -120,4 +126,71 @@ _Nothing has changed._
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeEmpty())
 	})
+
+	It("should fail if the repository url is invalid", func() {
+		// Given
+		config := modiff.NewConfig(badRepo, from, to, true, 1)
+
+		// When
+		res, err := modiff.Run(config)
+
+		// Then
+		Expect(err).To(HaveOccurred())
+		Expect(res).To(BeEmpty())
+	})
 })
+
+func TestCheckURLValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+		err      error
+		client   *http.Client
+	}{
+		{
+			name:     "Valid URL",
+			url:      "https://github.com/hashicorp/consul/compare/api/v1.18.0...api/v1.20.0",
+			expected: true,
+			err:      nil,
+		},
+		{
+			name:     "Invalid URL",
+			url:      "https://github.com/hashicorp/consul/compare/v1.18.0...v1.20.0",
+			expected: false,
+			err:      nil,
+		},
+		{
+			name:     "Request Sending Error",
+			url:      "invalid-url",
+			expected: false,
+			err:      fmt.Errorf("error while sending request: "),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			if tt.client == nil {
+				tt.client = &http.Client{}
+			}
+			valid, err := modiff.CheckURLValid(*tt.client, tt.url)
+			g.Expect(valid).To(Equal(tt.expected))
+			if tt.err != nil {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.err.Error()))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes an issue with the dependency links where we [remove the module name from the link](https://github.com/saschagrunert/go-modiff/blob/main/pkg/modiff/modiff.go#L218). This logic did account for tags with multiple slashes, but not tags with one slash. To get around this, we make a request to the page to see if the link is valid.

To test this, run the following command:
```
go-modiff -r github.com/kubernetes-sigs/cluster-api-provider-azure --from v1.12.0 --to v1.13.0
```

Observe the `github.com/hashicorp/consul/api` dependency has tags such as `api/v1.20.0`. The `api` part was removed, making the links invalid.

cc @saschagrunert 