### PR TITLE
Various performance fixups

### DIFF
--- a/pkg/modiff/modiff.go
+++ b/pkg/modiff/modiff.go
@@ -66,7 +66,7 @@ func Run(config *Config) (string, error) {
 	toRepo := filepath.Join(dir, "to")
 
 	logrus.Infof("Cloning base repository for %s to %s", config.repository, referenceRepo)
-	if err := runGit(dir, "clone", "--filter=blob:none", toURL(config.repository), referenceRepo); err != nil {
+	if err := runGit(dir, "clone", "--filter=blob:none", "--bare", toURL(config.repository), referenceRepo); err != nil {
 		return logErr(err)
 	}
 

--- a/pkg/modiff/modiff_test.go
+++ b/pkg/modiff/modiff_test.go
@@ -158,7 +158,7 @@ func TestCheckURLValid(t *testing.T) {
 		},
 		{
 			name:     "Invalid URL",
-			url:      "https://github.com/hashicorp/consul/compare/v1.18.0...v1.20.0",
+			url:      "https://github.com/hashicorp/consul/compare/v1.18.0...v9.99.0",
 			expected: false,
 			err:      nil,
 		},


### PR DESCRIPTION
A few random changes that should be entirely backwards-compatible, but also speed up the tool quite a bit.

### Git cloning

1. Use a [reference repository](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---reference-if-ablerepository) for the git clones rather than cloning the repository from scratch twice. By doing this, we clone the repository once (the 'reference'), then for our 'before' and 'after' clones git can just reference the existing clone. This saves disk space, but more importantly saves time cloning the repository if the repo is large, the user's bandwidth is limited, etc.
2. Pass `--filter=blob:none` to `git clone`. This tells Git to download all the information about commits, branches, etc., but not to download the file contents until it's needed. When git does a checkout (e.g. after the first clone) it will download any blobs it needs in order to finish the checkout, i.e. the contents of any files as of that tag. For large repositories, this also saves a large amount of time.
3. Clone the reference repository as `--bare` so that it doesn't bother to do an initial checkout.

### Mod diffing

1. Scan through the 'before' and 'after' mods list and store them in a hash. Then, when we're scanning through each mod, we can check to see if the same mod was present in both mod lists; if so, we know it's a duplicate and can ignore it.
2. Add some debug logging to the "fetch the remote URL to see if it works" code so that we can tell what the code is doing if it's hung up on something.
3. Use `http.MethodHead` instead of `http.MethodGet`; since we don't actually care about the contents of the URL and only whether it exists or not, we can do a `HEAD` request. This can speed things up if the server knows how to handle these properly, as it means it won't have to generate the entire page and can just return a `200 OK` if it exists. This may save us time, but may also save the remote server's processing and it's always nice to be nice.

### Performance change

I tested with this command:

```shell
build/go-modiff -r github.com/projectcalico/calico -f v3.30.0 -t v3.30.2
```

* Original: `1.28s user 1.00s system 3% cpu 57.738 total`
* Updated: `3.58s user 2.89s system 63% cpu 10.218 total`

Also testing with a much larger internal repository:

* Original: `3.29s user 2.32s system 6% cpu 1:20.43 total`
* Updated `8.00s user 6.06s system 57% cpu 24.536 total`

### Test fix

One of the 'valid URL' tests was broken because the URL it was testing was valid and shouldn't have been; I've fixed it by replacing it with a URL that will likely never be valid.	